### PR TITLE
Change NMath#recip into a module function

### DIFF
--- a/lib/narray_ext.rb
+++ b/lib/narray_ext.rb
@@ -272,6 +272,7 @@ module NMath
     ((x-xm)*(y-ym)).sum(*ranks) / (n-1)
   end
 
+  module_function :recip
   module_function :csc,:sec,:cot,:csch,:sech,:coth
   module_function :acsc,:asec,:acot,:acsch,:asech,:acoth
   module_function :covariance


### PR DESCRIPTION
Now NMath#recip is a instance method of module NMath, not a module function, and we can't use
it as NMath.recip(NArray[1.0, 2.0, 3.0]). 

I think it will be useful if the method is a module function.
