### PR TITLE
Fix ancestor checking

### DIFF
--- a/narray.c
+++ b/narray.c
@@ -181,11 +181,10 @@ static void
   if (TYPE(v) != T_CLASS) {
     rb_raise(rb_eRuntimeError, "class required");
   }
-  while (v) {
-    if (v == cNArray || RCLASS(v)->m_tbl == RCLASS(cNArray)->m_tbl)
-      return;
-    v = RCLASS_SUPER(v);
-  }
+
+  if(RTEST(rb_ary_includes(rb_mod_ancestors(v), cNArray)))
+    return;
+
   rb_raise(rb_eRuntimeError, "need NArray or its subclass");
 }
 


### PR DESCRIPTION
I was trying to use narray with ruby 1.9.3 and the falcon patchset (https://gist.github.com/4136519) - but it doesn't compile because the falcon patch moves m_tbl into a different struct.

As far as I can tell, this is functionally equivalent and hopefully safer.
