### PR TITLE
Add MinGW support for u_int16_t

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -89,6 +89,8 @@ end
 
 have_type("u_int8_t", header)
 have_type("uint8_t", header)
+have_type("u_int16_t", header)
+have_type("uint16_t", header)
 have_type("int16_t", header)
 have_type("int32_t", header)
 have_type("u_int32_t", header)

--- a/narray.h
+++ b/narray.h
@@ -49,6 +49,14 @@ typedef short                  int16_t;  /* NA_SINT */
 # endif
 #endif /* HAVE_INT16_T */
 
+#ifndef HAVE_U_INT16_T
+# ifdef HAVE_UINT16_T
+typedef uint16_t            u_int16_t;
+# else
+typedef unsigned short      u_int16_t;
+# endif
+#endif /* HAVE_UINT16_T */
+
 #ifndef HAVE_INT32_T
 # if SIZEOF_LONG == 4
 typedef long                   int32_t;  /* NA_LINT */


### PR DESCRIPTION
Please see details below. Successfully installed updated gem on:
- Win7 32bit mingw.org gcc 4.6.2 ruby 1.9.3p374 (2013-01-15 revision 38833) [i386-mingw32]
- Win7 32bit mingw-w64 gcc 4.7.2 ruby 2.0.0dev (2013-01-30 trunk 38993) [i386-mingw32]
- Arch Linux 3.7.4 gcc 4.7.2 ruby 2.0.0dev (2013-01-30 trunk 38993) [i686-linux]
